### PR TITLE
Fix Chef 13 deprecation warning

### DIFF
--- a/recipes/logrotate.rb
+++ b/recipes/logrotate.rb
@@ -5,7 +5,7 @@ logrotate_app 'amazon-ssm-agent' do
   )
   rotate node['ssm_agent']['logrotate']['rotate']
   frequency node['ssm_agent']['logrotate']['frequency']
-  options node['ssm_agent']['logrotate']['options']
+  options node['ssm_agent']['logrotate']['options'] if node['ssm_agent']['logrotate']['options']
   postrotate node['ssm_agent']['logrotate']['postrotate']
   template_mode '0644'
 end


### PR DESCRIPTION
This should fix the following deprecation warning:
```
nil is an invalid value for options of resource logrotate_app. In Chef 13, this warning will change to an error. Error: Property options must be one of: Array, String!  You passed nil.
```