### PR TITLE
(Chef 13) Support Amazon platform_family

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ default['ssm_agent'].tap do |config|
   config['package']['path'] = ::File.join(
     Chef::Config['file_cache_path'],
     value_for_platform_family('rhel' => 'amazon-ssm-agent.rpm',
+                              'amazon' => 'amazon-ssm-agent.rpm',
                               'debian' => 'amazon-ssm-agent.deb')
   )
 


### PR DESCRIPTION
Ohai 13+ detect Amazon Linux as a separate platform family